### PR TITLE
package.json: Fill in bugs.url

### DIFF
--- a/.github/tests/package.json
+++ b/.github/tests/package.json
@@ -13,7 +13,7 @@
   "author": "GGn0",
   "license": "ISC",
   "bugs": {
-    "url": ""
+    "url": "https://github.com/gmacario/gmacario.github.io/issues"
   },
   "homepage": "",
   "dependencies": {


### PR DESCRIPTION
Fix for avoiding warning from Visual Studio Code