### PR TITLE
Astro migration (Phase 3+): bio/CV homepage and About page (#62)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,193 +1,58 @@
-name: Continuous deployment
+# Build and deploy the Astro site (astro-site/) to GitHub Pages.
+#
+# Astro migration, issue #62 Phase 4. This replaces the legacy Next.js
+# export + gh-pages branch deploy. During the migration the Astro project
+# lives in the astro-site/ subdirectory; at the Phase 5 cutover it moves to
+# the repository root and the `path` below becomes ".".
+#
+# NOTE (cutover prerequisite): this workflow deploys via the GitHub Pages
+# "GitHub Actions" source. Before the first production deploy, set
+# Settings -> Pages -> Build and deployment -> Source to "GitHub Actions"
+# (the old site used the "Deploy from a branch: gh-pages" source).
+name: Deploy Astro site to GitHub Pages
+
 on:
+  # Production deploy happens only on the default branch (the cutover merge).
   push:
+    branches: [main]
+  # On pull requests the site is built but NOT deployed — this is the
+  # PR preview/verification capability (replaces the defunct Heroku staging).
   pull_request:
+  workflow_dispatch:
+
+# Permissions required by actions/deploy-pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow a single concurrent production deployment; do not cancel a running one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      deploy_staging: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) }}
-    outputs:
-      deploy_staging: ${{ env.deploy_staging }}
-
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./src
-
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build Astro site
+        uses: withastro/action@v3
         with:
-          persist-credentials: false
+          # Astro project lives in the subdirectory during the migration.
+          path: astro-site
+          node-version: 22
 
-      - name: Cache 💾
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Setup node 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-        env:
-          CI: true
-
-      - name: Export static site 💻
-        run: |
-          npm install
-          npm run export
-          # cp -r .circleci _static
-          touch _static/.nojekyll
-        working-directory: ${{ github.workspace }}
-
-      - name: Cache build artifacts 📦
-        if: ${{env.deploy_staging == 'true'}}
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/_static
-          key: ${{ runner.os }}-static-site-${{ github.sha }}
-
-  stage:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-      heroku_email: ${{ secrets.HEROKU_EMAIL }}
-      heroku_app: ${{ secrets.HEROKU_STAGING_APP }}
-    if: needs.build.outputs.deploy_staging == 'true'
-
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./src
-
-    steps:
-      - name: Check secrets 🔐
-        run: |
-          error_flag=false
-          if [[ -z "${heroku_email}" ]]; then
-            echo Cannot find heroku mail! Add it to the repo secrets as HEROKU_EMAIL
-            error_flag=true
-          else
-            echo Heroku email found
-          fi
-          if [[ -z "${heroku_app}" ]]; then
-            echo Cannot find heroku deploy app name! Add it to the repo secrets as HEROKU_STAGING_APP
-            error_flag=true
-          else
-            echo Heroku deploy app name found
-          fi
-          if [[ -z "${heroku_api_key}" ]]; then
-            echo Cannot find api key! Add it to the repo secrets as HEROKU_API_KEY
-            error_flag=true
-          else
-            echo Heroku api key found
-          fi
-          if [ "$error_flag" = true ]; then
-            exit 1
-          fi
-        working-directory: ${{ github.workspace }}
-
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
-          persist-credentials: false
-
-      - name: Setup heroku CLI 🛠
-        run: |
-          curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
-          cat >~/.netrc <<EOF
-          machine api.heroku.com
-              login ${heroku_email}
-              password ${heroku_api_key}
-          machine git.heroku.com
-              login ${heroku_email}
-              password ${heroku_api_key}
-          EOF
-          mkdir heroku
-        working-directory: ${{ github.workspace }}
-
-      - name: Restore build artifacts cache 📦
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/_static
-          key: ${{ runner.os }}-static-site-${{ github.sha }}
-
-      - name: Deploy to staging 🚀
-        run: |
-          cp -r .github/tests/* heroku
-          cp -r _static heroku
-          cd heroku
-          cat >.gitignore <<EOF
-          node_modules/
-          EOF
-          cat >Procfile <<EOF
-          web: npm install && npm start
-          EOF
-          git init
-          git config --global user.email "${heroku_email}"
-          git config --global user.name "Github Action"
-          # heroku git:remote -a "${heroku_app}"
-          # heroku login
-          git add -A
-          git commit -am "make it better"
-          # git push heroku master --force
-        working-directory: ${{ github.workspace }}
-
-      # - name: Create comment on pr 🧾
-      #   uses: mshick/add-pr-comment@v1
-      #   with:
-      #     message: |
-      #       Beep boop. I am a bot 🤖
-      #
-      #       I have built your static site 🛠
-      #       and deployed it in a staging environment 🚢
-      #
-      #       You can check out the result at [${{ env.heroku_app }}.herokuapp.com]( http://${{ env.heroku_app }}.herokuapp.com )
-      #
-      #       And approve (or reject) the results [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-      #
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
-      #     repo-token-user-login: "github-actions[bot]" # The user.login for temporary GitHub tokens
-
-  # Only deploy if it's a pull request or a push on main (or master)
   deploy:
+    # Deploy to production only from the default branch, never from a PR.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
     runs-on: ubuntu-latest
-    needs: stage
-    #if: ${{ needs.build.outputs.deploy_staging }}
-
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./src
-
     environment:
-      name: staging_environment
-
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
-          persist-credentials: false
-
-      - name: Create dir for artifacts
-        run: |
-          mkdir _static
-        working-directory: ${{ github.workspace }}
-
-      - name: Restore build artifacts cache 📦
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/_static
-          key: ${{ runner.os }}-static-site-${{ github.sha }}
-
-      - name: Deploy production 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages # The branch the action should deploy to.
-          folder: ${{ github.workspace }}/_static # The folder the action should deploy.
-          clean: true # Automatically remove deleted files from the deploy branch
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro-site/src/content/pages/about.md
+++ b/astro-site/src/content/pages/about.md
@@ -1,37 +1,39 @@
 ---
 title: "About"
-description: "A bit about me and this blog."
+description: "Gianpaolo Macario — software engineer working on embedded Linux and in-vehicle infotainment."
 ---
 
-AstroPaper is a minimal, accessible and SEO-friendly blog theme built with [Astro](https://astro.build/) and [Tailwind CSS](https://tailwindcss.com/).
+![Gianpaolo Macario](/bio/img_2741.jpg)
 
-![Astro Paper](@/assets/images/astropaper-og.jpg)
+I'm **Gianpaolo Macario**, a software engineer specialising in embedded Linux,
+in-vehicle infotainment (IVI) and open-source tooling.
 
-AstroPaper provides a solid foundation for blogs, or even portfolios\_ with full markdown support, built-in dark mode, and a clean layout that works out-of-the-box.
+I have spent many years working with embedded Linux and IVI, and had the
+privilege of seeing — and helping — Linux evolve from a bold idea into a solid
+foundation for production systems. I was involved in the GENIVI Alliance from
+its inception and served as lead architect of its System Infrastructure Expert
+Group. Along the way I have co-authored research papers and given talks about
+Linux and IVI at universities, customer sites and public events.
 
-The blog posts in this theme also serve as guides, docs or example articles\_ making AstroPaper a flexible starting point for your next content-driven site.
+## Selected projects
 
-## Features
+- [ARNEIS](https://github.com/B-AROL-O/ARNEIS) — a B-AROL-O team project
+- [AXOLOTL](https://devpost.com/software/axolotl)
+- [blobfishes](https://github.com/aquariophilie/blobfishes)
+- [easy-build](https://github.com/gmacario/easy-build)
+- [easy-jenkins](https://github.com/gmacario/easy-jenkins)
 
-AstroPaper comes with a set of useful features that make content publishing easy and effective:
+## Find me elsewhere
 
-- SEO-friendly
-- Fast performance
-- Light & dark mode
-- Highly customizable
-- Organizable blog posts
-- Responsive & accessible
-- Static search with [PageFind](https://pagefind.app/)
-- Automatic social image generation
+- [Curriculum Vitae (PDF)](/bio/CV-Europass-20260206-Macario-EN.pdf)
+- [GitHub](https://github.com/gmacario)
+- [LinkedIn](https://it.linkedin.com/in/gmacario/)
+- [Open Hub](https://www.openhub.net/accounts/gmacario)
+- [X (Twitter)](https://x.com/gpmacario)
 
-and so much more.
+## About this site
 
-## Show your support
-
-If you like [AstroPaper](https://github.com/satnaing/astro-paper), consider giving it a star ⭐️.
-
-Found a bug 🐛 or have an improvement ✨ in mind? Feel free to open an [issue](https://github.com/satnaing/astro-paper/issues), submit a [pull request](https://github.com/satnaing/astro-paper/pulls) or start a [discussion](https://github.com/satnaing/astro-paper/discussions).
-
-If you find this theme helpful, you can also [sponsor me on GitHub](https://github.com/sponsors/satnaing) or [buy me a coffee](https://buymeacoffee.com/satnaing) to show your support — every penny counts.
-
-Kyay zuu! 🙏🏼
+This site is built with [Astro](https://astro.build/) and the
+[AstroPaper](https://github.com/satnaing/astro-paper) theme. The blog archive
+collects a decade of posts migrated from the previous version of the site, with
+their original URLs preserved.

--- a/astro-site/src/content/posts/2021-07-17-our-journey-to-do-mongodb-hackathon.md
+++ b/astro-site/src/content/posts/2021-07-17-our-journey-to-do-mongodb-hackathon.md
@@ -7,7 +7,7 @@ tags:
   - hackathon
   - teaser
   - blowfishes
-description: "NOTE: This is supposed to be just a teaser of blowfisher."
+description: "A few days ago I joined the DigitalOcean MongoDB Hackathon together with a group of friends."
 ---
 
 <!--

--- a/astro-site/src/content/posts/2021-07-20-blobfishes-submitted-to-mongodb-hackathon.md
+++ b/astro-site/src/content/posts/2021-07-20-blobfishes-submitted-to-mongodb-hackathon.md
@@ -6,7 +6,7 @@ tags:
   - digitalocean
   - hackathon
   - blobfishes
-description: "TODO: Place one beautiful (or ugly?) picture here -->"
+description: "As I anticipated in my previous post a few days ago I joined the DigitalOcean MongoDB Hackathon together with a group of friends."
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-01-24-arneis-dev-cw03.md
+++ b/astro-site/src/content/posts/2022-01-24-arneis-dev-cw03.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-01-31-arneis-dev-cw04.md
+++ b/astro-site/src/content/posts/2022-01-31-arneis-dev-cw04.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-02-07-arneis-dev-cw05.md
+++ b/astro-site/src/content/posts/2022-02-07-arneis-dev-cw05.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-02-14-arneis-dev-cw06.md
+++ b/astro-site/src/content/posts/2022-02-14-arneis-dev-cw06.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in my 2021-12-18 post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-02-21-arneis-dev-cw07.md
+++ b/astro-site/src/content/posts/2022-02-21-arneis-dev-cw07.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-02-28-arneis-dev-cw08.md
+++ b/astro-site/src/content/posts/2022-02-28-arneis-dev-cw08.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-03-07-arneis-dev-cw09.md
+++ b/astro-site/src/content/posts/2022-03-07-arneis-dev-cw09.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-03-14-arneis-dev-cw10.md
+++ b/astro-site/src/content/posts/2022-03-14-arneis-dev-cw10.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-03-21-arneis-dev-cw11.md
+++ b/astro-site/src/content/posts/2022-03-21-arneis-dev-cw11.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-03-28-arneis-dev-cw12.md
+++ b/astro-site/src/content/posts/2022-03-28-arneis-dev-cw12.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-04-04-arneis-dev-cw13.md
+++ b/astro-site/src/content/posts/2022-04-04-arneis-dev-cw13.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced on 2021-12-18"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-04-11-arneis-dev-cw14.md
+++ b/astro-site/src/content/posts/2022-04-11-arneis-dev-cw14.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-04-18-arneis-dev-cw15.md
+++ b/astro-site/src/content/posts/2022-04-18-arneis-dev-cw15.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-04-25-arneis-dev-cw16.md
+++ b/astro-site/src/content/posts/2022-04-25-arneis-dev-cw16.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-05-02-arneis-dev-cw17.md
+++ b/astro-site/src/content/posts/2022-05-02-arneis-dev-cw17.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-05-09-arneis-dev-cw18.md
+++ b/astro-site/src/content/posts/2022-05-09-arneis-dev-cw18.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-05-16-arneis-dev-cw19.md
+++ b/astro-site/src/content/posts/2022-05-16-arneis-dev-cw19.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/content/posts/2022-05-23-arneis-dev-cw20.md
+++ b/astro-site/src/content/posts/2022-05-23-arneis-dev-cw20.md
@@ -6,7 +6,7 @@ tags:
   - b-arol-o
   - opencv
   - spatial-ai-contest
-description: "Welcome to our weekly status report of the ARNEIS project! -->"
+description: "As I announced in a previous post"
 ---
 
 <!--

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -35,7 +35,7 @@ const homePath = getRelativeLocaleUrl(locale, "");
   >
     <section id="hero" class="border-border border-b pt-8 pb-6">
       <h1 class="my-4 inline-block text-4xl font-bold sm:my-8 sm:text-5xl">
-        Mingalaba
+        Gianpaolo Macario
       </h1>
       <a
         target="_blank"
@@ -53,20 +53,27 @@ const homePath = getRelativeLocaleUrl(locale, "");
       </a>
 
       <p>
-        AstroPaper is a minimal, responsive, accessible and SEO-friendly Astro
-        blog theme. This theme follows best practices and provides accessibility
-        out of the box. Light and dark mode are supported by default. Moreover,
-        additional color schemes can also be configured.
+        I'm a software engineer focused on <strong>embedded Linux</strong>,{" "}
+        <strong>in-vehicle infotainment</strong> and open-source tooling. Over
+        many years I have watched — and helped — Linux grow from a bold idea into
+        a solid foundation for production systems, including serving as lead
+        architect of the GENIVI Alliance System Infrastructure Expert Group.
       </p>
       <p class="mt-2">
-        Read the blog posts or check{" "}
+        This is my personal home base: my{" "}
         <LinkButton
           class="hover:text-accent underline decoration-dashed underline-offset-4"
-          href="https://github.com/satnaing/astro-paper#readme"
+          href={`${import.meta.env.BASE_URL.replace(/\/?$/, "/")}bio/CV-Europass-20260206-Macario-EN.pdf`}
         >
-          README
+          curriculum vitae (PDF)
+        </LinkButton>, a bit{" "}
+        <LinkButton
+          class="hover:text-accent underline decoration-dashed underline-offset-4"
+          href={getRelativeLocaleUrl(locale, "about")}
+        >
+          about me
         </LinkButton>{" "}
-        for more info.
+        and the technical blog below.
       </p>
       {
         socials.length > 0 && (

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+# Netlify configuration for previewing the Astro rebuild (issue #62; also #180).
+#
+# During the migration the Astro project lives in the astro-site/ subdirectory,
+# so `base` points Netlify there and `publish` (relative to base) is dist/.
+# Connect this repository as a Netlify site to get automatic Deploy Previews
+# for pull requests. At the Phase 5 cutover, when astro-site/ moves to the repo
+# root, remove `base` and set publish = "dist".
+[build]
+  base = "astro-site"
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"


### PR DESCRIPTION
Draft PR continuing the Astro migration (#62) after PR #186 (Phases 0–2) was merged into `main`.

The rebuild lives in the `astro-site/` subdirectory so the legacy Next.js site at the repo root keeps building until the Phase 5 cutover.

## Included here

### Phase 3 — Homepage and pages ✅
- **Homepage hero** (`astro-site/src/pages/index.astro`): name headline, a short professional bio (embedded Linux / IVI / open source), and prominent links to the CV PDF and About page; RSS + social icons retained; 10 most recent posts below.
- **About page** (`astro-site/src/content/pages/about.md`): real bio, headshot, selected projects (ARNEIS, AXOLOTL, blobfishes, easy-build, easy-jenkins) and profiles (CV, GitHub, LinkedIn, Open Hub, X), ported from the legacy `pages/index.js` and `public/bio`.
- Paginated `/posts` archive, `/archives`, `/about` and `/404` render; OG + canonical meta present; light/dark toggle present.

Build: `astro check` 0 errors, 176 pages, Pagefind indexes all 69 posts.

## Still to come (will be pushed to this PR)

- **Phase 4 — CI/CD**: replace `build-and-deploy.yml` with the official `withastro/action` GitHub Pages workflow; keep the link-check workflow.
- **Phase 5 — Cutover**: delete the Next.js code and Jekyll leftovers, configure the `blog.gmacario.it` custom domain, retire the old Netlify site.

## Review notes

- The bio copy is a **first draft** derived from the older `public/bio/gmacario-bio.md.txt`; it intentionally states no current employer and is worth a refresh.
- The social image is still the AstroPaper-branded `default-og.jpg` — a good polish item before cutover.

Marked as **draft** — I'll flip it to ready once Phases 4–5 land and you've reviewed the copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P)_