### PR TITLE
CNAME: add blog.gmacario.it

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+blog.gmacario.it


### PR DESCRIPTION
## CNAME: add custom domain for the Astro blog

Add a `CNAME` file containing `blog.gmacario.it`, which is required by GitHub Pages to enable custom domain support.

### Manual follow-ups after merge

1. **GitHub Pages → Settings → Custom domain** — enter `blog.gmacario.it` and save (triggers HTTPS certificate provisioning)
2. **register.it DNS** — repoint from the old Netlify URL (`stoic-newton-ff8d72.netlify.app`) to `gmacario.github.io`

### Related

- Part of Phase 5 cutover: #188