### PR TITLE
Refresh bio copy on homepage hero and /about

### DIFF
--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -26,6 +26,13 @@ about Linux and IVI at universities, customer sites and public events.
 
 ## Selected projects
 
+- [FREISA](https://github.com/B-AROL-O/FREISA) — I lead this B-AROL-O team
+  project building a four-legged robot for intelligent sprinkler automation.
+  It has since grown into FREISA-GPT, an AI-powered interactive companion
+  integrating an open-weight LLM for voice commands and physical robot
+  actions on ROS2. FREISA won the Grand Prize at the OpenCV AI Competition
+  2023, was a finalist at the OpenAI Open Model Hackathon, and was featured
+  in The MagPi Magazine and Tom's Hardware.
 - [ARNEIS](https://github.com/B-AROL-O/ARNEIS) — a B-AROL-O team project
 - [AXOLOTL](https://devpost.com/software/axolotl)
 - [blobfishes](https://github.com/aquariophilie/blobfishes)

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -1,19 +1,28 @@
 ---
 title: "About"
-description: "Gianpaolo Macario — software engineer working on embedded Linux and in-vehicle infotainment."
+description: "Gianpaolo Macario — Senior Software Architect at AROL Group, working on embedded systems, IoT and open-source tooling."
 ---
 
 ![Gianpaolo Macario](/bio/img_2741.jpg)
 
-I'm **Gianpaolo Macario**, a software engineer specialising in embedded Linux,
-in-vehicle infotainment (IVI) and open-source tooling.
+I'm **Gianpaolo Macario**, a software architect specialising in embedded
+systems, IoT and open-source tooling.
 
-I have spent many years working with embedded Linux and IVI, and had the
-privilege of seeing — and helping — Linux evolve from a bold idea into a solid
-foundation for production systems. I was involved in the GENIVI Alliance from
-its inception and served as lead architect of its System Infrastructure Expert
-Group. Along the way I have co-authored research papers and given talks about
-Linux and IVI at universities, customer sites and public events.
+I'm currently **Senior Software Architect and Site Manager** at
+[AROL Group](https://www.arol.com/), where I lead the R&D site in Turin,
+Italy. Recent projects include an on-premise agentic LLM system that
+supports the sales team, and a BLE-based sensor network for instrumenting
+capping machinery. I'm also cofounder and CTO of
+[SOLARMA](https://www.solarma.it/), a small company designing and operating
+photovoltaic systems.
+
+Earlier in my career I spent several years working with embedded Linux and
+in-vehicle infotainment (IVI) at Mentor Graphics, and had the privilege of
+seeing — and helping — Linux evolve from a bold idea into a solid foundation
+for production systems. I was involved in the GENIVI Alliance from its
+inception and served as lead architect of its System Infrastructure Expert
+Group. Along the way I have co-authored research papers and given talks
+about Linux and IVI at universities, customer sites and public events.
 
 ## Selected projects
 

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -3,7 +3,7 @@ title: "About"
 description: "Gianpaolo Macario — Senior Software Architect at AROL Group, working on embedded systems, IoT and open-source tooling."
 ---
 
-![Gianpaolo Macario](/bio/img_2741.jpg)
+<img src="/bio/img_2741.jpg" alt="Gianpaolo Macario" width="200" />
 
 I'm **Gianpaolo Macario**, a software architect specialising in embedded
 systems, IoT and open-source tooling.
@@ -26,18 +26,26 @@ about Linux and IVI at universities, customer sites and public events.
 
 ## Selected projects
 
-- [FREISA](https://github.com/B-AROL-O/FREISA) — I lead this B-AROL-O team
-  project building a four-legged robot for intelligent sprinkler automation.
-  It has since grown into FREISA-GPT, an AI-powered interactive companion
-  integrating an open-weight LLM for voice commands and physical robot
-  actions on ROS2. FREISA won the Grand Prize at the OpenCV AI Competition
-  2023, was a finalist at the OpenAI Open Model Hackathon, and was featured
-  in The MagPi Magazine and Tom's Hardware.
+- [FREISA](https://github.com/B-AROL-O/FREISA) — a four-legged robot for
+  intelligent sprinkler automation, which I lead within the B-AROL-O team.
+  Now evolved into FREISA-GPT, an LLM-powered companion on ROS2; Grand Prize
+  winner at the OpenCV AI Competition 2023 and a finalist at the OpenAI Open
+  Model Hackathon.
 - [ARNEIS](https://github.com/B-AROL-O/ARNEIS) — a B-AROL-O team project
-- [AXOLOTL](https://devpost.com/software/axolotl)
-- [blobfishes](https://github.com/aquariophilie/blobfishes)
-- [easy-build](https://github.com/gmacario/easy-build)
-- [easy-jenkins](https://github.com/gmacario/easy-jenkins)
+  simulating an Industry 4.0 bottle-sorting machine, combining OpenCV spatial
+  AI, LEGO Technic hardware and a hybrid Kubernetes cluster spanning Azure
+  and edge Raspberry Pis; finalist at the OpenCV Spatial AI Contest.
+- [AXOLOTL](https://devpost.com/software/axolotl) — a wine-bottle
+  traceability app generating QR codes linked to Confluence pages, built for
+  Atlassian's Codegeist 2021 hackathon.
+- [blobfishes](https://github.com/aquariophilie/blobfishes) — a
+  deliberately-ugly Node.js/MongoDB/Docker web app built for the
+  DigitalOcean MongoDB Hackathon.
+- [easy-build](https://github.com/gmacario/easy-build) — Dockerfiles for
+  rebuilding embedded software distributions such as AOSP, OpenWrt and the
+  Yocto Project.
+- [easy-jenkins](https://github.com/gmacario/easy-jenkins) — deploys a
+  Jenkins CI/CD stack via docker-machine and docker-compose.
 
 ## Find me elsewhere
 

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -9,10 +9,10 @@ I'm **Gianpaolo Macario**, a software architect specialising in embedded
 systems, IoT and open-source tooling.
 
 I'm currently **Senior Software Architect and Site Manager** at
-[AROL Group](https://www.arol.com/), where I lead the R&D site in Turin,
-Italy. Recent projects include an on-premise agentic LLM system that
-supports the sales team, and a BLE-based sensor network for instrumenting
-capping machinery. I'm also cofounder and CTO of
+[AROL Group](https://www.arol.com/), where I'm technically responsible for
+the R&D site in Turin, Italy. Recent projects include an on-premise agentic
+LLM system that supports the sales team, and a BLE-based sensor network for
+instrumenting capping machinery. I'm also cofounder and CTO of
 [SOLARMA](https://www.solarma.it/), a small company designing and operating
 photovoltaic systems.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,11 +53,12 @@ const homePath = getRelativeLocaleUrl(locale, "");
       </a>
 
       <p>
-        I'm a software engineer focused on <strong>embedded Linux</strong>,{" "}
-        <strong>in-vehicle infotainment</strong> and open-source tooling. Over
-        many years I have watched — and helped — Linux grow from a bold idea into
-        a solid foundation for production systems, including serving as lead
-        architect of the GENIVI Alliance System Infrastructure Expert Group.
+        I'm a software architect focused on <strong>embedded systems</strong>,{" "}
+        <strong>IoT</strong> and open-source tooling. I currently lead R&D
+        projects at <strong>AROL Group</strong> as Senior Software Architect
+        and Site Manager, building on years of experience in embedded Linux
+        and in-vehicle infotainment — including serving as lead architect of
+        the GENIVI Alliance System Infrastructure Expert Group.
       </p>
       <p class="mt-2">
         This is my personal home base: my{" "}


### PR DESCRIPTION
## Summary

- Rewrites the bio copy on the homepage hero and the `/about` page to reflect the current professional situation, replacing the vague "software engineer" placeholder that implied no current employer.
- Cross-referenced against `CV-Europass-20260206-Macario-EN.pdf` (the `gmacario-cv-en.html` file in `public/bio/` is stale, last updated 2016).
- Homepage hero now mentions the current role — Senior Software Architect and Site Manager at AROL Group — alongside the embedded Linux / GENIVI background.
- `/about` page rewritten with current AROL Group projects (on-premise agentic LLM system, BLE sensor network), the SOLARMA cofounder/CTO role, and the Mentor Graphics/GENIVI history moved to "earlier in my career." Updated the page's meta description accordingly.
- Softened an initial "I lead the R&D site" claim to "I'm technically responsible for the R&D site" to match the actual reporting structure.

Closes #194.

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npx astro build` — verified rendered output for `/` and `/about/` shows the updated copy correctly (including `R&D` rendering as plain text, not an HTML entity issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P)_