### PR TITLE
Add Cloudflare Web Analytics beacon (#131)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,6 +40,14 @@ jobs:
         uses: withastro/action@v3
         with:
           node-version: 22
+        env:
+          # Cloudflare Web Analytics beacon token (#131). Stored as a repository
+          # variable, not a secret: Cloudflare embeds it in the page markup, so
+          # it is public by design. Keeping it here rather than in
+          # astro-paper.config.ts means Netlify staging/preview builds never
+          # receive it, so their traffic stays out of the production statistics.
+          # When the variable is unset the beacon is simply omitted.
+          PUBLIC_CLOUDFLARE_BEACON_TOKEN: ${{ vars.PUBLIC_CLOUDFLARE_BEACON_TOKEN }}
 
   deploy:
     # Deploy to production only from the default branch, never from a PR.

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -136,6 +136,7 @@ ignorePatterns:
   - pattern: '^https?://www\.raspberrypi\.com/products/raspberry-pi-3-model-b/'
   - pattern: '^https?://www\.arduino\.cc/pro/hardware/product/portenta-x8'
   - pattern: '^https?://[^/]*\.linkedin\.com/'
+  - pattern: '^https?://dash\.cloudflare\.com/'
 
 userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
 followRedirects: true

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ Netlify serves:
 Build configuration is declared in [`netlify.toml`](netlify.toml) (config as
 code); no repository secrets are used for the deploy.
 
+## Analytics
+
+The site uses [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/),
+which is cookieless and collects no personal data — so the site needs no cookie
+consent banner. Production is hosted on GitHub Pages, which exposes no server
+access logs, so a client-side beacon is the only option available.
+
+To enable it, add the site in the Cloudflare dashboard and set the resulting
+beacon token as a **repository variable** named
+`PUBLIC_CLOUDFLARE_BEACON_TOKEN` (Settings → Secrets and variables → Actions →
+Variables). It is deliberately a variable rather than a secret: Cloudflare
+embeds the token in the page markup, so it is public by design.
+
+The token is read only by the production workflow, which means Netlify staging
+and deploy-preview builds never carry the beacon and their traffic stays out of
+the statistics. When the variable is unset the beacon is omitted entirely and
+no analytics are collected. Setting `analytics.cloudflareBeaconToken` in
+[`astro-paper.config.ts`](astro-paper.config.ts) instead would enable it for
+every build, previews included.
+
 ## Copyright and license
 
 Disclaimer: [IANAL](https://en.wikipedia.org/wiki/IANAL)

--- a/astro-paper.config.ts
+++ b/astro-paper.config.ts
@@ -38,6 +38,13 @@ export default defineAstroPaperConfig({
     },
     search: "pagefind",
   },
+  analytics: {
+    // Cloudflare Web Analytics (#131). The token is intentionally NOT set here:
+    // it is supplied by the PUBLIC_CLOUDFLARE_BEACON_TOKEN environment variable
+    // in .github/workflows/build-and-deploy.yml, so only production GitHub Pages
+    // builds carry the beacon and Netlify previews stay out of the statistics.
+    // Setting `cloudflareBeaconToken` here would enable it everywhere instead.
+  },
   socials: [
     { name: "github", url: "https://github.com/gmacario" },
     { name: "x", url: "https://x.com/gpmacario" },

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -76,6 +76,14 @@ export default defineConfig({
         context: "client",
         optional: true,
       }),
+      // Cloudflare Web Analytics beacon token (#131). Not a secret -- it is
+      // embedded in the page markup by design. Set in the production deploy
+      // workflow only, so Netlify previews stay out of the statistics.
+      PUBLIC_CLOUDFLARE_BEACON_TOKEN: envField.string({
+        access: "public",
+        context: "client",
+        optional: true,
+      }),
     },
   },
   experimental: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,10 @@
  */
 import userConfig from "@/astro-paper.config";
 import type { ResolvedAstroPaperConfig } from "./types/config";
-import { PUBLIC_GOOGLE_SITE_VERIFICATION } from "astro:env/client";
+import {
+  PUBLIC_CLOUDFLARE_BEACON_TOKEN,
+  PUBLIC_GOOGLE_SITE_VERIFICATION,
+} from "astro:env/client";
 
 const DEFAULT_OG_IMAGE = "default-og.jpg";
 
@@ -33,6 +36,11 @@ const config: ResolvedAstroPaperConfig = {
     showBackButton: userConfig.features?.showBackButton ?? true,
     editPost: userConfig.features?.editPost ?? { enabled: false },
     search: userConfig.features?.search ?? "pagefind",
+  },
+  analytics: {
+    cloudflareBeaconToken:
+      userConfig.analytics?.cloudflareBeaconToken ||
+      PUBLIC_CLOUDFLARE_BEACON_TOKEN,
   },
   socials: userConfig.socials ?? [],
   shareLinks: userConfig.shareLinks ?? [],

--- a/src/content/posts/2026-07-24-cloudflare-web-analytics-instead-of-google-analytics.md
+++ b/src/content/posts/2026-07-24-cloudflare-web-analytics-instead-of-google-analytics.md
@@ -1,0 +1,197 @@
+---
+title: "Ditching Google Analytics: a beginner's guide to Cloudflare Web Analytics"
+pubDatetime: 2026-07-24T00:00:00+02:00
+tags:
+  - analytics
+  - privacy
+  - cloudflare
+  - astro
+  - blog
+description: "Why this blog uses Cloudflare Web Analytics instead of Google Analytics, how it compares to GoatCounter, Plausible and Umami, and a step-by-step, newbie-friendly guide to setting it up."
+---
+
+I wanted basic traffic numbers for this blog — nothing fancy, just "is anyone
+reading this" — without dragging in Google Analytics and everything that comes
+with it. Here's the comparison I did, the alternative I picked, and the exact
+steps to set it up, in case you want to do the same on your own site.
+
+## Why not just use Google Analytics?
+
+GA4 is free and extremely capable, but for a personal blog it brings baggage
+that's disproportionate to the job:
+
+- **It needs a cookie consent banner.** GA sets cookies to track visitors
+  across sessions, which means you're legally required (under the EU's
+  ePrivacy rules) to ask for consent before it loads. That's a banner, a
+  consent-management script, and a worse experience for every reader.
+- **It's a lot of machinery for "how many people read this."** A full
+  analytics suite, a separate Google account, a dashboard with more options
+  than a personal blog will ever need.
+- **It ships a fair amount of JavaScript** to a static site that otherwise
+  loads almost instantly.
+
+None of that is disqualifying if you need GA's depth — e-commerce funnels,
+audience segments, ad attribution. For a blog, it's overkill.
+
+## The alternatives I considered
+
+Before picking one, I compared four options that all describe themselves as
+"privacy-friendly": they don't use cookies, don't track individuals across
+sites, and don't need a consent banner.
+
+| Option | Cost | Cookies? | Self-hostable? | Notes |
+| --- | --- | --- | --- | --- |
+| **Cloudflare Web Analytics** | Free, unlimited | No | No | Zero accounts to manage beyond an existing/new Cloudflare login; lightest setup |
+| **GoatCounter** | Free for personal use | No | Yes (single Go binary) | Open source, very small script, simple dashboard |
+| **Umami** | Free self-hosted / paid cloud | No | Yes (needs Postgres or MySQL) | Nicer dashboard than GoatCounter, a bit more to run yourself |
+| **Plausible** | ~$9–14/month | No | Yes (heavier: ClickHouse + Postgres) | The most polished dashboard of the four, but the paid tier or a non-trivial self-host |
+
+One thing ruled out an option I initially considered and skipped from the
+table above: **server log-based analytics**. This blog is hosted on **GitHub
+Pages**, which is a static file host — it keeps no server access logs at all.
+So log-based tools, and anything that only sees requests hitting your own
+server (like Netlify's built-in analytics, which would only ever see this
+site's *deploy previews*, not real production traffic), were never on the
+table. Whatever I picked had to be a small script embedded in the page
+itself.
+
+I ended up choosing **Cloudflare Web Analytics**. It's free with no usage
+cap, needs no server or database of my own to run, and if you don't already
+have a Cloudflare account, creating one is the only "infrastructure" step —
+everything else is copypasting one token. GoatCounter is a very close second
+and is worth a look if you'd rather not have a Cloudflare account at all.
+
+## Setting it up (step by step)
+
+This assumes a static site — the steps are the same regardless of what
+generator you use, though the "where does the token go" part will differ
+slightly if you're not using Astro.
+
+### 1. Create a Cloudflare account (skip if you already have one)
+
+Go to [dash.cloudflare.com/sign-up](https://dash.cloudflare.com/sign-up) and
+create a free account. **You do not need to point your domain's DNS at
+Cloudflare** — Web Analytics works as a standalone product on any site.
+
+### 2. Add your site to Web Analytics
+
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. In the left sidebar, find **Analytics & Logs → Web Analytics**.
+3. Click **Add a site**.
+4. Enter your site's hostname (for this blog, `blog.gmacario.it`) and save.
+
+### 3. Get your beacon token
+
+After adding the site, Cloudflare shows you a snippet that looks like this:
+
+```html
+<script
+  defer
+  src="https://static.cloudflareinsights.com/beacon.min.js"
+  data-cf-beacon='{"token": "YOUR_BEACON_TOKEN_GOES_HERE"}'
+></script>
+```
+
+The part you actually need is the **token** — that long hex string inside
+`data-cf-beacon`. That's it: there's no username/password pair, no OAuth
+flow, no API key to generate separately. The token is the credential, and
+it's meant to be public — it's sitting in plain sight in every page's HTML,
+by design, so there's nothing to keep secret about it.
+
+If you just want the snippet on a plain HTML site, you can stop here: paste
+that `<script>` tag right before `</body>` on every page and you're done.
+
+### 4. Wiring it into an Astro site (what this blog does)
+
+Because this is a static site built and deployed by CI, hardcoding the token
+into a template isn't quite the best move — it would mean **every** build,
+including PR preview builds on Netlify, sends traffic to the same analytics
+dashboard, mixing real visitors with my own testing. Instead:
+
+1. **Declare the token as an environment variable**, not a hardcoded string,
+   using Astro's typed env schema (`astro.config.ts`):
+
+   ```ts
+   env: {
+     schema: {
+       PUBLIC_CLOUDFLARE_BEACON_TOKEN: envField.string({
+         access: "public",
+         context: "client",
+         optional: true,
+       }),
+     },
+   },
+   ```
+
+2. **Read it in the site config**, falling back to `undefined` when unset —
+   so the beacon is simply skipped if nothing is configured:
+
+   ```ts
+   analytics: {
+     cloudflareBeaconToken:
+       userConfig.analytics?.cloudflareBeaconToken ||
+       PUBLIC_CLOUDFLARE_BEACON_TOKEN,
+   },
+   ```
+
+3. **Render the script tag conditionally** in the shared page layout, only
+   when a token is present and only in production builds:
+
+   ```astro
+   {
+     cfBeaconToken && (
+       <script
+         is:inline
+         defer
+         src="https://static.cloudflareinsights.com/beacon.min.js"
+         data-cf-beacon={JSON.stringify({ token: cfBeaconToken })}
+       />
+     )
+   }
+   ```
+
+4. **Set the actual token as a repository variable** in GitHub (Settings →
+   Secrets and variables → Actions → Variables), named
+   `PUBLIC_CLOUDFLARE_BEACON_TOKEN` — a **variable**, not a secret, since (as
+   noted above) the token ends up in public page HTML anyway.
+
+5. **Pass it only to the production deploy job**, not to preview builds:
+
+   ```yaml
+   - name: Build Astro site
+     uses: withastro/action@v3
+     env:
+       PUBLIC_CLOUDFLARE_BEACON_TOKEN: ${{ vars.PUBLIC_CLOUDFLARE_BEACON_TOKEN }}
+   ```
+
+The result: production (GitHub Pages) carries the beacon; Netlify staging
+and PR preview deploys never get the variable, so they never send data to
+the dashboard, and my own clicking-around during testing doesn't skew the
+numbers.
+
+### 5. Check that data is arriving
+
+Give it a few minutes after your next deploy, then visit **Analytics & Logs
+→ Web Analytics** in the Cloudflare dashboard and pick your site. You should
+start seeing page views, top pages, referrers and country-level breakdowns —
+no cookies, no consent banner, no personal data collected.
+
+## The honest caveat
+
+This site uses Astro's [View
+Transitions](https://docs.astro.build/en/guides/view-transitions/)
+(`<ClientRouter />`), which means navigating between pages swaps the DOM
+instead of triggering a full browser page load. I haven't yet confirmed
+whether Cloudflare's beacon correctly counts those in-page navigations as
+separate page views, or whether it only sees the very first load. If your
+site uses view transitions or a similar client-side router, it's worth
+checking your numbers against expectations once real traffic arrives, rather
+than assuming it "just works."
+
+## Bottom line
+
+If you run a personal site on a static host and want a rough sense of who's
+reading without becoming a part-time analytics administrator, Cloudflare Web
+Analytics (or GoatCounter, if you'd rather avoid another platform account) is
+a five-minute job that never needs a cookie banner. Save Google Analytics for
+when you actually need what only it provides.

--- a/src/content/posts/2026-07-25-cloudflare-web-analytics-instead-of-google-analytics.md
+++ b/src/content/posts/2026-07-25-cloudflare-web-analytics-instead-of-google-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: "Ditching Google Analytics: a beginner's guide to Cloudflare Web Analytics"
-pubDatetime: 2026-07-24T00:00:00+02:00
+pubDatetime: 2026-07-25T00:00:00+02:00
 tags:
   - analytics
   - privacy

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,6 +23,19 @@ const {
   canonicalURL = new URL(Astro.url.pathname, Astro.site).href,
 } = Astro.props;
 
+// Cloudflare Web Analytics (#131): cookieless, so no consent banner needed.
+// Skipped in `astro dev` so local browsing isn't counted as real traffic.
+//
+// The beacon sits in <head> with `defer`, so it loads without blocking render.
+// `is:inline` keeps Astro from bundling it, leaving the token on the tag.
+//
+// Caveat: this site uses <ClientRouter /> (view transitions), which swaps the
+// DOM instead of doing full page loads. Confirm in the Cloudflare dashboard
+// that in-site navigations are counted once analytics is live.
+const cfBeaconToken = import.meta.env.PROD
+  ? config.analytics.cloudflareBeaconToken
+  : undefined;
+
 const socialImageURL = new URL(ogImage, Astro.site ?? Astro.url);
 const rssHref = getRelativeLocaleUrl(
   Astro.currentLocale ?? config.site.lang,
@@ -91,6 +104,17 @@ const rssHref = getRelativeLocaleUrl(
         <meta
           name="google-site-verification"
           content={site.googleVerification}
+        />
+      )
+    }
+
+    {
+      cfBeaconToken && (
+        <script
+          is:inline
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon={JSON.stringify({ token: cfBeaconToken })}
         />
       )
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -61,6 +61,21 @@ interface FeaturesConfig {
   search?: "pagefind" | false;
 }
 
+interface AnalyticsConfig {
+  /**
+   * Cloudflare Web Analytics beacon token (issue #131). Cookieless and
+   * privacy-preserving, so it needs no consent banner.
+   *
+   * Prefer setting this via the PUBLIC_CLOUDFLARE_BEACON_TOKEN environment
+   * variable in the production deploy workflow rather than hardcoding it
+   * here: Netlify staging/preview builds don't get that variable, so their
+   * traffic stays out of the production statistics.
+   *
+   * The token is not a secret — Cloudflare embeds it in the page markup.
+   */
+  cloudflareBeaconToken?: string;
+}
+
 interface SocialLink {
   /**
    * Must match an SVG filename in src/assets/icons/socials/.
@@ -96,6 +111,8 @@ interface AstroPaperConfig {
   site: SiteConfig;
   posts?: PostsConfig;
   features?: FeaturesConfig;
+  /** Third-party analytics. Omit entirely to collect no statistics. */
+  analytics?: AnalyticsConfig;
   /** Social profile links shown in header/footer */
   socials?: SocialLink[];
   /** Share links shown on post detail pages */
@@ -121,6 +138,7 @@ export interface ResolvedAstroPaperConfig {
   site: ResolvedSiteConfig;
   posts: Required<PostsConfig>;
   features: Required<FeaturesConfig>;
+  analytics: AnalyticsConfig;
   socials: SocialLink[];
   shareLinks: ShareLink[];
 }


### PR DESCRIPTION
Closes #131.

## Why Cloudflare Web Analytics rather than Google Analytics

- **No consent banner needed.** The beacon sets no cookies and collects no personal data, so it doesn't trigger ePrivacy cookie consent the way GA does. GA4 would have meant adding a consent management layer.
- **Free and unlimited**, with no account-level maintenance.
- **A client-side beacon is the only option available.** Production is GitHub Pages, which exposes no server access logs — that rules out log-based analytics (including Netlify Analytics, which would only ever see deploy previews).

## What this does

- Adds an optional `analytics.cloudflareBeaconToken` config field, resolved from `PUBLIC_CLOUDFLARE_BEACON_TOKEN` through Astro's env schema — mirroring the existing `PUBLIC_GOOGLE_SITE_VERIFICATION` pattern already in `src/config.ts`.
- `build-and-deploy.yml` passes the token from a repository **variable**, not a secret: Cloudflare embeds it in the page markup, so it's public by design.
- **Previews stay out of the statistics.** Because the token comes from the production workflow rather than `astro-paper.config.ts`, Netlify staging and deploy-preview builds never receive it. `astro-paper.config.ts` documents this tradeoff for anyone tempted to hardcode it there.
- The beacon is omitted entirely when no token is set, and skipped in `astro dev`.
- README gained an "Analytics" section covering the setup steps and rationale.

## Action needed before this collects anything

This PR is inert until you add the site at **Cloudflare dashboard → Web Analytics** and set the beacon token as a repository variable named `PUBLIC_CLOUDFLARE_BEACON_TOKEN` (Settings → Secrets and variables → Actions → Variables). Until then the build simply omits the beacon.

## Known caveat worth checking once live

The site uses `<ClientRouter />` (view transitions), which swaps the DOM instead of doing full page loads. I couldn't verify from here whether Cloudflare's beacon counts those in-site navigations — worth a look at the dashboard once real traffic arrives. Flagged in a code comment too.

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] Build **with** a token: all 184 pages emit `<script defer src=".../beacon.min.js" data-cf-beacon="{&quot;token&quot;:...}">`
- [x] Build **without** a token: 0 pages contain any beacon reference
- [x] `npm run lint` — clean apart from two pre-existing `no-console` errors in `.github/tests/server.js` (present on `main`, unrelated to this change)
- [x] textlint clean on the README changes; workflow YAML parses and resolves the `vars.` expression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P)_