### PR TITLE
Add blog post: bringing up k3s-gmhome with Ansible

### DIFF
--- a/public/assets/2026-07-27-bringing-up-k3s-gmhome-with-ansible/hero.svg
+++ b/public/assets/2026-07-27-bringing-up-k3s-gmhome-with-ansible/hero.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="k3s-gmhome: a 3-node HA k3s cluster on Raspberry Pi 5, brought up with Ansible">
+  <rect width="1200" height="630" fill="#fefbfb"/>
+  <rect x="56" y="60" width="1092" height="514" rx="10" fill="#ecebeb" stroke="#000" stroke-width="4"/>
+  <rect x="40" y="44" width="1092" height="514" rx="10" fill="#fefbfb" stroke="#000" stroke-width="4"/>
+
+  <g font-family="ui-monospace, 'Google Sans Code', 'Cascadia Code', 'DejaVu Sans Mono', monospace">
+    <text x="88" y="130" font-size="30" fill="#666" letter-spacing="1">k3s-gmhome</text>
+
+    <!-- Rack unit 1 -->
+    <g>
+      <rect x="88" y="168" width="640" height="76" rx="6" fill="#1f2430" stroke="#000" stroke-width="3"/>
+      <circle cx="118" cy="206" r="9" fill="#3ddc72"/>
+      <text x="148" y="216" font-size="30" font-weight="700" fill="#f4f4f4">rpi5gm51</text>
+      <text x="420" y="216" font-size="22" fill="#9aa0a6">4 GiB · control-plane</text>
+    </g>
+
+    <!-- Rack unit 2 -->
+    <g>
+      <rect x="88" y="260" width="640" height="76" rx="6" fill="#1f2430" stroke="#000" stroke-width="3"/>
+      <circle cx="118" cy="298" r="9" fill="#3ddc72"/>
+      <text x="148" y="308" font-size="30" font-weight="700" fill="#f4f4f4">rpi5gm52</text>
+      <text x="420" y="308" font-size="22" fill="#9aa0a6">8 GiB · control-plane</text>
+    </g>
+
+    <!-- Rack unit 3 -->
+    <g>
+      <rect x="88" y="352" width="640" height="76" rx="6" fill="#1f2430" stroke="#000" stroke-width="3"/>
+      <circle cx="118" cy="390" r="9" fill="#3ddc72"/>
+      <text x="148" y="400" font-size="30" font-weight="700" fill="#f4f4f4">rpi5gm53</text>
+      <text x="420" y="400" font-size="22" fill="#9aa0a6">16 GiB · control-plane</text>
+    </g>
+
+    <!-- kube-vip virtual IP tag, bracketing the three master nodes -->
+    <path d="M 748 168 h 40 v 260 h -40" fill="none" stroke="#006cac" stroke-width="4"/>
+    <rect x="792" y="270" width="220" height="56" rx="6" fill="#006cac"/>
+    <text x="812" y="306" font-size="24" font-weight="700" fill="#ffffff">kube-vip VIP</text>
+
+    <text x="88" y="466" font-size="36" fill="#2a2a2a" font-weight="700">3-node HA k3s cluster, stood up with Ansible</text>
+    <text x="88" y="504" font-size="24" fill="#666">Raspberry Pi 5 &#183; kube-vip &#183; MetalLB &#183; Ansible Vault</text>
+    <text x="792" y="540" font-size="26" font-weight="700" fill="#1a1a1a">gmacario.github.io</text>
+  </g>
+</svg>

--- a/src/content/posts/2026-07-22-migrating-this-blog-to-astro.md
+++ b/src/content/posts/2026-07-22-migrating-this-blog-to-astro.md
@@ -6,7 +6,6 @@ tags:
   - blog
   - migration
   - ai
-featured: true
 description: "Why I rebuilt gmacario.github.io on Astro and AstroPaper, and how I did the whole migration pair-programming with Claude Code."
 ogImage: "../../assets/2026-07-22-migrating-this-blog-to-astro-og.png"
 ---

--- a/src/content/posts/2026-07-27-bringing-up-k3s-gmhome-with-ansible.md
+++ b/src/content/posts/2026-07-27-bringing-up-k3s-gmhome-with-ansible.md
@@ -1,0 +1,230 @@
+---
+title: "Bringing up k3s-gmhome: a 3-node HA Kubernetes cluster with Ansible"
+pubDatetime: 2026-07-27T00:00:00+02:00
+tags:
+  - ansible
+  - k3s
+  - kubernetes
+  - raspberry-pi5
+  - homelab
+description: "How I used Ansible and the community k3s-ansible collection to bring up a 3-node, highly-available k3s cluster on Raspberry Pi 5 hardware — kube-vip, MetalLB, Ansible Vault, and a couple of bugs found along the way."
+---
+
+I've been slowly rebuilding my home lab (`gmhome`) around a proper, reproducible
+Ansible codebase instead of a pile of one-off SSH sessions. The centerpiece is
+`k3s-gmhome`: a 3-node, highly-available [k3s](https://k3s.io/) cluster running
+on Raspberry Pi 5 hardware, brought up entirely from an Ansible playbook. Here's
+how it's put together.
+
+## The hardware
+
+Three Raspberry Pi 5 boards, deliberately not identical — I had the parts on
+hand rather than buying a matched set:
+
+| Hostname | CPU | RAM | Storage |
+| --- | --- | ---: | --- |
+| rpi5gm51 | Raspberry Pi 5 Model B Rev 1.0 | 4 GiB | 1 TB NVMe SSD |
+| rpi5gm52 | Raspberry Pi 5 Model B Rev 1.0 | 8 GiB | 2 TB NVMe SSD |
+| rpi5gm53 | Raspberry Pi 5 Model B Rev 1.1 | 16 GiB | 2 TB NVMe SSD |
+
+Each node boots straight off NVMe (no microSD in the loop), gets its power from
+a shared multi-port GaN USB-C supply, and its network from a PoE+ switch. All of
+it lives in a small rack-mounted enclosure rather than a shelf of loose boards.
+
+## Why all-master, no workers
+
+The cluster runs all three nodes as control-plane/etcd/master — there's no
+separate worker group yet. That's a deliberate simplification: with only three
+nodes, running them all as masters gives etcd quorum and spreads workloads
+across all the capacity I have, without the added complexity of a fourth
+role to manage. The inventory already has an empty `k3s_gmhome_worker` group
+ready for whenever I add dedicated workers.
+
+## OS and network prep
+
+Each Pi runs **Ubuntu Server 24.04.3 LTS** installed straight to NVMe via
+`rpi-imager`'s network-boot installer, with SSH and locale/timezone
+(`Europe/Rome`) set during imaging. After first boot, every node gets:
+
+- [Tailscale](https://tailscale.com/kb/1031/install-linux) installed, for
+  out-of-band access independent of the LAN.
+- Passwordless `sudo` for the `ubuntu` user, so Ansible can run privileged
+  tasks without prompting.
+
+The nodes talk to each other over a plain LAN subnet (`192.168.7.0/24`), not
+over Tailscale — more on why below.
+
+## Ansible setup
+
+The inventory groups the three Pis under `k3s_gmhome_master`:
+
+```ini
+[k3s_gmhome_master]
+rpi5gm51    ansible_host=rpi5gm51.tailXXXXX.ts.net   ansible_user='ubuntu'
+rpi5gm52    ansible_host=rpi5gm52.tailXXXXX.ts.net   ansible_user='ubuntu'
+rpi5gm53    ansible_host=rpi5gm53.tailXXXXX.ts.net   ansible_user='ubuntu'
+
+[k3s_gmhome_worker]
+; (empty for now)
+
+[k3s_gmhome:children]
+k3s_gmhome_master
+k3s_gmhome_worker
+```
+
+`ansible_host` actually points at each node's Tailscale hostname — that's just
+how Ansible *reaches* the nodes over SSH from my dev container; it's separate
+from what the cluster itself uses internally (see below). Before touching k3s,
+a few ad-hoc commands are enough to sanity-check the fleet:
+
+```bash
+ansible k3s_gmhome -a "date"
+ansible k3s_gmhome -a "df -h" -f 1
+ansible k3s_gmhome -m ansible.builtin.apt -a "upgrade=dist" -b
+```
+
+### Keeping the join token out of Git with Ansible Vault
+
+The k3s cluster join token is a shared secret, so it's encrypted at rest with
+[Ansible Vault](https://docs.ansible.com/projects/ansible/latest/vault_guide/index.html)
+rather than sitting in `group_vars` as plaintext:
+
+```bash
+k3s_token=$(uuidgen)
+ansible-vault encrypt_string --name k3s_token "$k3s_token"
+```
+
+The output — an inline `!vault` block — gets pasted into
+`inventory/group_vars/k3s_gmhome.yml`, and the vault password itself lives in a
+local, gitignored `vault-password.enc` file (`*.enc` is excluded via
+`.gitignore`), so a fresh clone always has to recreate it before the playbook
+will run. Once the cluster exists, the same token can be read straight off any
+master at `/var/lib/rancher/k3s/server/token` if it's ever needed by hand.
+
+## The playbook
+
+Rather than writing k3s bring-up logic from scratch, the playbook builds on
+the community
+[`techno_tim.k3s_ansible`](https://github.com/timothystewart6/k3s-ansible)
+collection (as covered in
+[Techno Tim's k3s-etcd-ansible writeup](https://technotim.live/posts/k3s-etcd-ansible/)),
+which already encodes the fiddly parts of a highly-available k3s install.
+`playbooks/k3s_gmhome_install.yml` just sequences its roles against the right
+host groups:
+
+```yaml
+- name: Prepare k3s nodes
+  hosts: k3s_gmhome
+  roles:
+    - role: techno_tim.k3s_ansible.prereq
+      become: true
+    - role: techno_tim.k3s_ansible.download
+      become: true
+    - role: techno_tim.k3s_ansible.raspberrypi
+      become: true
+
+- name: Setup k3s servers
+  hosts: k3s_gmhome_master
+  roles:
+    - role: techno_tim.k3s_ansible.k3s_server
+      become: true
+
+- name: Setup k3s agents
+  hosts: k3s_gmhome_worker
+  roles:
+    - role: techno_tim.k3s_ansible.k3s_agent
+      become: true
+
+- name: Configure k3s cluster
+  hosts: k3s_gmhome_master
+  roles:
+    - role: techno_tim.k3s_ansible.k3s_server_post
+      become: true
+```
+
+All the actual tuning lives in `inventory/group_vars/k3s_gmhome.yml`, which is
+a trimmed-down copy of the collection's own sample vars file. The interesting
+choices:
+
+- **[kube-vip](https://kube-vip.io/)** provides a virtual IP
+  (`192.168.7.15`) for the control-plane API server, shared across all three
+  masters via ARP — so `kubectl` keeps working even if any single master goes
+  down.
+- **[MetalLB](https://metallb.io/)**, in Layer 2 mode, hands out
+  `LoadBalancer` service IPs from `192.168.7.20`–`192.168.7.29` (kept outside
+  the DHCP range on purpose). k3s's built-in `servicelb` and bundled Traefik
+  are both explicitly disabled, since real MetalLB and a separately-managed
+  Traefik take their place.
+- **flannel** is the CNI (the default for this collection); Calico and
+  Cilium are supported alternatives in the same vars file but weren't needed
+  here.
+
+### A deliberate constraint: no Tailscale IPs inside the cluster
+
+The cluster's internal traffic and the kube-vip virtual IP both stay on the
+plain LAN, not on the tailnet. The reason is structural: there's currently no
+way to allocate a virtual IP *inside* a tailnet for kube-vip to bind to, so
+routing the control-plane VIP over Tailscale would quietly break the HA setup
+it's there to provide. It also means every node has to sit on the same LAN
+subnet — a real limitation, though the
+[Tailscale Kubernetes Operator](https://tailscale.com/kb/1236/kubernetes-operator)
+offers a way to expose specific *services* to the tailnet afterwards without
+touching that constraint.
+
+## Bringing it up
+
+```bash
+uv sync
+ansible-galaxy install -r collections/requirements.yml
+ansible-playbook playbooks/k3s_gmhome_install.yml
+```
+
+The one part worth expecting: the "verify that all nodes actually joined"
+task retries for a while before succeeding — normal on a first bring-up while
+etcd finds quorum across three fresh nodes, not a sign of failure. A few
+minutes later:
+
+```text
+NAME       STATUS   ROLES                       AGE   VERSION
+rpi5gm51   Ready    control-plane,etcd,master   54m   v1.33.5+k3s1
+rpi5gm52   Ready    control-plane,etcd,master   54m   v1.33.5+k3s1
+rpi5gm53   Ready    control-plane,etcd,master   54m   v1.33.5+k3s1
+```
+
+with CoreDNS, kube-vip, MetalLB, metrics-server and the local-path
+provisioner already running across all three nodes.
+
+If something goes sideways instead, there's a matching teardown playbook
+(`k3s_gmhome_teardown.yml`) that resets every node back to a clean slate, and
+`journalctl --unit=k3s-init.service` on the affected node is usually the
+fastest way to see what k3s itself thinks went wrong before re-running the
+install.
+
+## Two bugs a later review caught
+
+A configuration review some months after the initial bring-up turned up two
+things worth mentioning, since neither was obvious just from a successful
+playbook run:
+
+- Both the install and teardown playbooks referenced `vars_files: vars/k3s.yml`
+  — a file that had never actually been committed. Testing against the pinned
+  `ansible-core` version confirmed a missing `vars_files` entry is silently
+  ignored rather than fatal, so this was dead, misleading configuration rather
+  than a play-breaking bug. Removed, since every real variable already lives in
+  `inventory/group_vars/k3s_gmhome.yml`.
+- The install playbook's "Prepare k3s nodes" play listed the
+  `techno_tim.k3s_ansible.raspberrypi` role **twice**. `ansible-playbook
+  --list-tasks` confirmed its cgroup/`linux-modules-extra-raspi` tasks were
+  genuinely running twice per node. Removed the duplicate, matching the
+  upstream collection's own role ordering.
+
+Both fixes were verified with `--syntax-check` and `--list-tasks` rather than
+re-run against the live cluster, since neither one changes actual cluster
+state — a good reminder that a playbook succeeding end-to-end doesn't mean
+every line in it is doing something meaningful.
+
+## What's next
+
+This covers just standing the cluster up. Ingress (Traefik), persistent
+storage (Longhorn), and monitoring (Grafana Cloud) are separate pieces layered
+on top afterward — maybe material for a follow-up post once they've settled.

--- a/src/content/posts/2026-07-27-bringing-up-k3s-gmhome-with-ansible.md
+++ b/src/content/posts/2026-07-27-bringing-up-k3s-gmhome-with-ansible.md
@@ -7,8 +7,11 @@ tags:
   - kubernetes
   - raspberry-pi5
   - homelab
+featured: true
 description: "How I used Ansible and the community k3s-ansible collection to bring up a 3-node, highly-available k3s cluster on Raspberry Pi 5 hardware — kube-vip, MetalLB, Ansible Vault, and a couple of bugs found along the way."
 ---
+
+![k3s-gmhome: a 3-node HA k3s cluster on Raspberry Pi 5, brought up with Ansible](/assets/2026-07-27-bringing-up-k3s-gmhome-with-ansible/hero.svg)
 
 I've been slowly rebuilding my home lab (`gmhome`) around a proper, reproducible
 Ansible codebase instead of a pile of one-off SSH sessions. The centerpiece is


### PR DESCRIPTION
## Summary

A new post walking through how the `k3s-gmhome` cluster (3× Raspberry Pi 5, all-master HA topology) is brought up via Ansible:

- Hardware layout and why it's all-master with no dedicated workers yet.
- OS prep (Ubuntu Server 24.04.3, Tailscale, passwordless sudo).
- Inventory structure and Ansible Vault for the k3s join token.
- The `techno_tim.k3s_ansible` collection's playbook structure (prereq → download → raspberrypi → k3s_server → k3s_agent → k3s_server_post).
- The kube-vip (control-plane VIP) + MetalLB (LoadBalancer IPs) HA design, and the deliberate constraint of staying off Tailscale IPs internally (no way to allocate a virtual IP inside a tailnet for kube-vip).
- The actual install run and resulting `kubectl get nodes` output.
- Two real bugs a later config review caught (a dead `vars_files` reference, a duplicated role) — good material since neither was visible from a successful run.

## Sourcing

Everything here is read directly from your `gmhome-infra` repo (private — I added it to this session read-only): `docs/install-log-k3s-gmhome/README.md`, `playbooks/k3s_gmhome_install.yml`, `inventory/hosts.ini`, and `inventory/group_vars/k3s_gmhome.yml`. Nothing here is reconstructed from general knowledge of k3s/Ansible.

Two things I deliberately left out or changed:

- Dropped a link to `gmhome-infra` issue #279 (the config-review bug source) — that repo is private, so the link would 404 for every reader. The narrative content is preserved; only the dead hyperlink is gone.
- Redacted the real Tailscale tailnet hostname suffix (`tailXXXXX.ts.net` instead of the actual one) in the inventory snippet — no reason to publish that specifically.

## Review notes

- Written in first person as you; check the framing/tone before publishing.
- Scoped deliberately to the *bring-up* — Traefik, Longhorn, and Grafana Cloud monitoring are separate later chapters in your install log and are only mentioned as a "what's next," not covered in depth.
- `pubDatetime` is `2026-07-27T00:00:00+02:00` (today, backdated to midnight so it isn't hidden as a "scheduled" post).

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npx astro build` — 194 pages built
- [x] textlint, markdownlint, and a local gitleaks v8.30.1 scan (this repo's pinned ruleset) — all clean
- [x] Every external link verified against the real, public sources already cited in your install log (k3s.io, kube-vip.io, metallb.io, the `timothystewart6/k3s-ansible` collection, Techno Tim's blog, Tailscale's docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P)_