### PR TITLE
Credit Davide Macario in the k3s-gmhome post

### DIFF
--- a/src/content/posts/2026-07-27-bringing-up-k3s-gmhome-with-ansible.md
+++ b/src/content/posts/2026-07-27-bringing-up-k3s-gmhome-with-ansible.md
@@ -145,6 +145,11 @@ host groups:
       become: true
 ```
 
+None of this would have come together as quickly without
+[Davide Macario](https://github.com/davmacario), whose own internal writeup on
+the same topic was a huge source of inspiration for how I approached the whole
+bring-up.
+
 All the actual tuning lives in `inventory/group_vars/k3s_gmhome.yml`, which is
 a trimmed-down copy of the collection's own sample vars file. The interesting
 choices:


### PR DESCRIPTION
Adds a short acknowledgment to [Davide Macario](https://github.com/davmacario) in the "The playbook" section of the k3s-gmhome post — his internal writeup on the same topic was a huge source of inspiration for the bring-up.

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npx astro build` — 194 pages built
- [x] textlint, markdownlint, and a local gitleaks scan — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5zNapGJVSBmZMvbV2tJ3P)_